### PR TITLE
Implement FUV + tests

### DIFF
--- a/decide-app/src/main/java/com/decide/app/Decide.java
+++ b/decide-app/src/main/java/com/decide/app/Decide.java
@@ -33,8 +33,27 @@ public class Decide {
         return PUM;
     }
 
-    public boolean[] getFinalUnlockingVector(boolean[][] PUM) {
-        boolean[] FUV = new boolean[]{ true };
+    /**
+     * Final Unlocking Vector:
+     * The Preliminary Unlocking Matrix indicates whether the corresponding 
+     * LIC is to be considered as a factor in signaling interceptor launch. 
+     * FUV[i] should be set to true if PUV[i] is false (indicating that the 
+     * associated LIC should not hold back launch) or if all elements in 
+     * PUM row i are true.
+     * @param PreliminaryUnlockingMatrix The Preliminary Unlocking Matrix.
+     * @return The Final Unlocking Vector, an array of boolean values.
+     */
+    public boolean[] getFinalUnlockingVector(boolean[][] PreliminaryUnlockingMatrix) {
+        int n = PUV.length;
+        if (PreliminaryUnlockingMatrix.length < n) throw new IllegalArgumentException();
+        boolean[] FUV = new boolean[n];
+        for (int i = 0; i < FUV.length; ++i) {
+            FUV[i] = true;
+            if (PUV[i] == false) continue;
+            for (int j = 0; j < PreliminaryUnlockingMatrix[i].length; ++j) {
+                FUV[i] = FUV[i] && PreliminaryUnlockingMatrix[i][j];
+            }
+        }
         return FUV;
     }
 

--- a/decide-app/src/test/java/com/decide/app/DecideTest.java
+++ b/decide-app/src/test/java/com/decide/app/DecideTest.java
@@ -1,6 +1,7 @@
 package com.decide.app;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
@@ -41,7 +42,89 @@ public class DecideTest {
      * =========================== [ FUV ] ===========================
      */
 
-    
+    /**
+     * Positive test case, ensure that the elements in the FUV are true 
+     * only if all elements in the corresponding row in the PUM are true, 
+     * or if the corresponding value in the PUV is false.
+     */
+    @Test
+    public void FUVCorrespondsToPUMandPUV() {
+        boolean[] PUV = new boolean[]{
+            true,
+            true,
+            true,
+            true,
+            false,
+            true,
+            false,
+            true,
+            false,
+            true,
+            true,
+            true,
+            true,
+            false,
+            true
+        };
+        Decide decide = new Decide(0, null, PARAMETERS, null, PUV);
+        boolean[][] PUM = new boolean[][]{
+            {true, true, true, true, true, true, true, true, false, true, true, true, true, true, true},
+            {true, true, true, true, false, true, false, true, false, true, true, true, true, true, true},
+            {true, true, true, true, true, true, true, true, true, true, true, true, true, false, true},
+            {true, true, true, true, false, true, true, true, false, true, true, true, true, false, true},
+            {true, false, true, false, false, true, true, true, false, true, true, false, true, true, true},
+            {true, true, true, true, true, true, true, true, true, true, true, true, true, true, true},
+            {true, false, true, true, true, true, false, true, false, false, true, true, true, false, true},
+            {true, true, true, true, true, true, true, true, true, true, true, true, true, true, true},
+            {false, false, true, false, false, true, false, true, true, true, false, true, false, false, true},
+            {true, true, true, true, true, true, false, true, true, true, true, true, true, true, true},
+            {true, true, true, true, true, true, true, true, false, true, true, true, true, false, true},
+            {true, true, true, true, false, true, true, true, true, true, true, true, true, false, true},
+            {true, true, true, true, true, true, true, true, false, true, true, true, true, false, true},
+            {true, true, false, false, true, true, false, true, false, true, false, false, false, true, true},
+            {true, true, true, true, true, true, true, true, true, true, true, true, true, true, true}
+        };
+        boolean[] FUV_CORRECT = new boolean[]{
+            false,
+            false,
+            false,
+            false,
+            true,
+            true,
+            true,
+            true,
+            true,
+            false,
+            false,
+            false,
+            false,
+            true,
+            true
+        };
+        boolean[] FUV = decide.getFinalUnlockingVector(PUM);
+        assertTrue(FUV_CORRECT.length == FUV.length);
+        for (int i = 0; i < FUV.length; ++i) {
+            assertTrue(FUV[i] == FUV_CORRECT[i]);
+        }
+    }
+
+    /**
+     * Invalid input test case, ensure that an IllegalArgumentException
+     * is thrown if the input dimensions are not correct.
+     */
+    @Test
+    public void FUVThrowsExceptionOnInvalidDimensions() {
+        boolean[] PUV = new boolean[]{ true, true, true };
+        Decide decide = new Decide(0, null, PARAMETERS, null, PUV);
+        boolean[][] PUM = new boolean[][]{
+            {true, true, true},
+            {true, true, true}
+        };
+        assertThrows(
+            IllegalArgumentException.class, 
+            () -> { decide.getFinalUnlockingVector(PUM); }
+        );
+    }
 
     /**
      * ========================= [ LAUNCH ] ==========================


### PR DESCRIPTION
Implementation and tests for the Final Unlocking Vector. 
Throws IllegalArgumentException if there are more elements in the given PUV than rows in the PUM, otherwise input is considered valid under the definition "all values in the row are true", even though there may be varying elements per row, but is generally unnecessary.

Closes #23.