### PR TITLE
LIC10 + tests

### DIFF
--- a/decide-app/src/main/java/com/decide/app/LaunchInterceptorConditions.java
+++ b/decide-app/src/main/java/com/decide/app/LaunchInterceptorConditions.java
@@ -129,8 +129,43 @@ public class LaunchInterceptorConditions {
         return true;
     }
 
+    /**
+     * Launch Interceptor Condition 10:
+     * There exists at least one set of three data points separated
+     * by exactly E_PTS and F_PTS consecutive intervening points,
+     * respectively, that are the vertices of a triangle with area
+     * greater than AREA1. The condition is not met when NUMPOINTS < 5.
+     * Constraints:
+     * 1 ≤ E_PTS, 1 ≤ F_PTS
+     * E_PTS + F_PTS ≤ NUMPOINTS − 3
+     * @return True if the condition is met, false otherwise.
+     */
     public boolean getLaunchInterceptorCondition10() {
-        return true;
+        if (NUMPOINTS < 5) {
+            return false;
+        }
+        if (PARAMETERS.AREA1 < 0) throw new IllegalArgumentException("AREA is strictly negative");
+        if (PARAMETERS.E_PTS < 1 || PARAMETERS.F_PTS < 1) {
+            throw new IllegalArgumentException("E_PTS or F_PTS is negative or null");
+        }
+        if (PARAMETERS.E_PTS + PARAMETERS.F_PTS > NUMPOINTS - 3) {
+            throw new IllegalArgumentException("The sum of E_PTS and F_PTS is stricyl superior to NUMPOINTS - 3");
+        }
+
+        // implementation
+        for(int i = 0; i < NUMPOINTS - PARAMETERS.E_PTS - PARAMETERS.F_PTS - 2; i++) {
+            Point p1 = POINTS[i];
+            Point p2 = POINTS[i+PARAMETERS.E_PTS+1];
+            Point p3 = POINTS[i+PARAMETERS.E_PTS+1+PARAMETERS.F_PTS+1];
+            double distance1 = distance(p1, p2);
+            double distance2 = distance(p2, p3);
+            double distance3 = distance(p1, p3);
+            double S = (distance1+distance2+distance3)/2;
+            double Area = Math.sqrt(S*(S-distance1)*(S-distance2)*(S-distance3));
+            if (Area > PARAMETERS.AREA1) return true;
+        }
+
+        return false;
     }
 
     public boolean getLaunchInterceptorCondition11() {

--- a/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
+++ b/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
@@ -510,6 +510,7 @@ public class LaunchInterceptorConditionsTest {
             () -> { LIC.getLaunchInterceptorCondition10(); }
         );
     }
+
     /**
      * Illegal argument value test case for LIC10, ensures an exception is raised if the
      * value of F_PTS is negative or null.
@@ -539,6 +540,34 @@ public class LaunchInterceptorConditionsTest {
         );
     }
 
+    /**
+     * Illegal argument value test case for LIC10, ensures an exception is raised if
+     * E_PTS + F_PTS > NUMPOINTS - 3.
+     */
+    @Ignore
+    @Test
+    public void LIC10InvalidArgumentNegativeSumOfEptsAndFptsTooBig() {
+        PARAMETERS.AREA1 = 10;
+        Point[] POINTS = new Point[]{
+            new Point(0, 2),
+            new Point(1, 2),
+            new Point(2, 5),
+            new Point(0, 0),
+            new Point(1, 10),
+            new Point(1, 2),
+            new Point(2, 0)
+        };
+        int NUMPOINTS = POINTS.length;
+        PARAMETERS.E_PTS = NUMPOINTS;
+        PARAMETERS.F_PTS = NUMPOINTS;
+
+        LaunchInterceptorConditions LIC = new LaunchInterceptorConditions(NUMPOINTS, POINTS, PARAMETERS);
+
+        assertThrows(
+            IllegalArgumentException.class, 
+            () -> { LIC.getLaunchInterceptorCondition10(); }
+        );
+    }
 
     
     /**

--- a/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
+++ b/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
@@ -411,6 +411,34 @@ public class LaunchInterceptorConditionsTest {
         assertFalse(LIC.getLaunchInterceptorCondition10());
     }
 
+
+    /**
+     * Edge-case test case, ensure LIC10 is not satisfied when three points seperated by
+     * exactly E_PTS and F_PTS consecutive points respectively form a triangle of area
+     * equals to AREA1.
+     */
+    @Ignore
+    @Test
+    public void LIC10FalseTriangleOfAreaEqualToArea1() {
+        PARAMETERS.E_PTS = 2;
+        PARAMETERS.E_PTS = 2;
+        PARAMETERS.AREA1 = 2;
+        Point[] POINTS = new Point[]{
+            new Point(0, 2),
+            new Point(1, 2),
+            new Point(2, 5),
+            new Point(0, 0),
+            new Point(1, 10),
+            new Point(1, 2),
+            new Point(2, 0)
+        };
+        int NUMPOINTS = POINTS.length;
+
+        LaunchInterceptorConditions LIC = new LaunchInterceptorConditions(NUMPOINTS, POINTS, PARAMETERS);
+
+        assertFalse(LIC.getLaunchInterceptorCondition10());
+    }
+
     /**
      * ========================= [ LIC 11 ] ==========================
      */

--- a/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
+++ b/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
@@ -358,12 +358,12 @@ public class LaunchInterceptorConditionsTest {
 
     /**
      * Positive test case, ensure LIC10 is satisfied when three points seperated by
-     * exactly E_PTS and F_PTS consecutive pointsrespectively form a triangle of area
-     * striclty more than AREA1 apart.
+     * exactly E_PTS and F_PTS consecutive points respectively form a triangle of area
+     * striclty superior to AREA1.
      */
     @Ignore
     @Test
-    public void LIC10TrueOnPointsSeparatedByEptsAndFptsPointsOfAreaStrictlySuperiorToArea1() {
+    public void LIC10TrueTriangleOfAreaStrictlySuperiorToArea1() {
         PARAMETERS.E_PTS = 2;
         PARAMETERS.E_PTS = 2;
         PARAMETERS.AREA1 = 3;
@@ -386,8 +386,8 @@ public class LaunchInterceptorConditionsTest {
 
     /**
      * Negative test case, ensure LIC10 is not satisfied when three points seperated by
-     * exactly E_PTS and F_PTS consecutive pointsrespectively form a triangle of area
-     * inferior  than AREA1 apart.
+     * exactly E_PTS and F_PTS consecutive points respectively form a triangle of area
+     * inferior to AREA1.
      */
     @Ignore
     @Test

--- a/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
+++ b/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
@@ -3,7 +3,6 @@ package com.decide.app;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
-import org.junit.Ignore;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
@@ -11,7 +10,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 
 import org.junit.Test;
-import org.junit.Ignore;
 
 public class LaunchInterceptorConditionsTest {
     Parameters PARAMETERS;
@@ -361,11 +359,10 @@ public class LaunchInterceptorConditionsTest {
      * exactly E_PTS and F_PTS consecutive points respectively form a triangle of area
      * striclty superior to AREA1.
      */
-    @Ignore
     @Test
     public void LIC10TrueTriangleOfAreaStrictlySuperiorToArea1() {
         PARAMETERS.E_PTS = 2;
-        PARAMETERS.E_PTS = 2;
+        PARAMETERS.F_PTS = 2;
         PARAMETERS.AREA1 = 3;
         Point[] POINTS = new Point[]{
             new Point(4, 2),
@@ -389,11 +386,10 @@ public class LaunchInterceptorConditionsTest {
      * exactly E_PTS and F_PTS consecutive points respectively form a triangle of area
      * inferior to AREA1.
      */
-    @Ignore
     @Test
     public void LIC10FalseTriangleOfAreaInferiorToArea1() {
         PARAMETERS.E_PTS = 2;
-        PARAMETERS.E_PTS = 2;
+        PARAMETERS.F_PTS = 2;
         PARAMETERS.AREA1 = 3;
         Point[] POINTS = new Point[]{
             new Point(0, 1),
@@ -417,11 +413,10 @@ public class LaunchInterceptorConditionsTest {
      * exactly E_PTS and F_PTS consecutive points respectively form a triangle of area
      * equals to AREA1.
      */
-    @Ignore
     @Test
     public void LIC10FalseTriangleOfAreaEqualToArea1() {
         PARAMETERS.E_PTS = 2;
-        PARAMETERS.E_PTS = 2;
+        PARAMETERS.F_PTS = 2;
         PARAMETERS.AREA1 = 2;
         Point[] POINTS = new Point[]{
             new Point(0, 2),
@@ -442,7 +437,6 @@ public class LaunchInterceptorConditionsTest {
     /**
      * Unsufficient input test for LIC10, must return false if there are 5 points or less
      */
-    @Ignore
     @Test
     public void LIC10FalseOn5PointsOrLess() {
         Point[] POINTS = new Point[]{
@@ -460,7 +454,6 @@ public class LaunchInterceptorConditionsTest {
      * Illegal argument value test case for LIC10, ensures an exception is raised if the
      * value of AREA1 is strictly negative.
      */
-    @Ignore
     @Test
     public void LIC10InvalidArgumentStrictlyNegativeArea() {
         PARAMETERS.AREA1 = -1;
@@ -487,7 +480,6 @@ public class LaunchInterceptorConditionsTest {
      * Illegal argument value test case for LIC10, ensures an exception is raised if the
      * value of E_PTS is negative or null.
      */
-    @Ignore
     @Test
     public void LIC10InvalidArgumentNegativeOrNullEpts() {
         PARAMETERS.E_PTS = 0;
@@ -515,7 +507,6 @@ public class LaunchInterceptorConditionsTest {
      * Illegal argument value test case for LIC10, ensures an exception is raised if the
      * value of F_PTS is negative or null.
      */
-    @Ignore
     @Test
     public void LIC10InvalidArgumentNegativeOrNullFpts() {
         PARAMETERS.E_PTS = 1;
@@ -544,7 +535,6 @@ public class LaunchInterceptorConditionsTest {
      * Illegal argument value test case for LIC10, ensures an exception is raised if
      * E_PTS + F_PTS > NUMPOINTS - 3.
      */
-    @Ignore
     @Test
     public void LIC10InvalidArgumentNegativeSumOfEptsAndFptsTooBig() {
         PARAMETERS.AREA1 = 10;

--- a/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
+++ b/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
@@ -510,6 +510,34 @@ public class LaunchInterceptorConditionsTest {
             () -> { LIC.getLaunchInterceptorCondition10(); }
         );
     }
+    /**
+     * Illegal argument value test case for LIC10, ensures an exception is raised if the
+     * value of F_PTS is negative or null.
+     */
+    @Ignore
+    @Test
+    public void LIC10InvalidArgumentNegativeOrNullFpts() {
+        PARAMETERS.E_PTS = 1;
+        PARAMETERS.F_PTS = -1;
+        PARAMETERS.AREA1 = 1;
+        Point[] POINTS = new Point[]{
+            new Point(0, 2),
+            new Point(1, 2),
+            new Point(2, 5),
+            new Point(0, 0),
+            new Point(1, 10),
+            new Point(1, 2),
+            new Point(2, 0)
+        };
+        int NUMPOINTS = POINTS.length;
+
+        LaunchInterceptorConditions LIC = new LaunchInterceptorConditions(NUMPOINTS, POINTS, PARAMETERS);
+
+        assertThrows(
+            IllegalArgumentException.class, 
+            () -> { LIC.getLaunchInterceptorCondition10(); }
+        );
+    }
 
 
     

--- a/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
+++ b/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
@@ -456,6 +456,33 @@ public class LaunchInterceptorConditionsTest {
         assertFalse(LIC.getLaunchInterceptorCondition10());
     }
 
+    /**
+     * Illegal argument value test case for LIC10, ensures an exception is raised if the
+     * value of AREA1 is strictly negative.
+     */
+    @Ignore
+    @Test
+    public void LIC10InvalidArgumentStrictlyNegativeArea() {
+        PARAMETERS.AREA1 = -1;
+        Point[] POINTS = new Point[]{
+            new Point(0, 2),
+            new Point(1, 2),
+            new Point(2, 5),
+            new Point(0, 0),
+            new Point(1, 10),
+            new Point(1, 2),
+            new Point(2, 0)
+        };
+        int NUMPOINTS = POINTS.length;
+
+        LaunchInterceptorConditions LIC = new LaunchInterceptorConditions(NUMPOINTS, POINTS, PARAMETERS);
+
+        assertThrows(
+            IllegalArgumentException.class, 
+            () -> { LIC.getLaunchInterceptorCondition10(); }
+        );
+    }
+
 
     
     /**

--- a/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
+++ b/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
@@ -3,6 +3,7 @@ package com.decide.app;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
+import org.junit.Ignore;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
@@ -10,6 +11,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 
 import org.junit.Test;
+import org.junit.Ignore;
 
 public class LaunchInterceptorConditionsTest {
     Parameters PARAMETERS;
@@ -201,7 +203,32 @@ public class LaunchInterceptorConditionsTest {
      * ========================= [ LIC 10 ] ==========================
      */
 
-    
+    /**
+     * Positive test case, ensure LIC10 is satisfied when three points seperated by
+     * exactly E_PTS and F_PTS consecutive pointsrespectively form a triangle of area
+     * striclty more than AREA1 apart.
+     */
+    @Ignore
+    @Test
+    public void LIC10TrueOnPointsSeparatedByEptsAndFptsPointsOfAreaStrictlySuperiorToArea1() {
+        PARAMETERS.E_PTS = 2;
+        PARAMETERS.E_PTS = 2;
+        PARAMETERS.AREA1 = 3;
+        Point[] POINTS = new Point[]{
+            new Point(4, 2),
+            new Point(1, 2),
+            new Point(2, 5),
+            new Point(10, 7),
+            new Point(1, 10),
+            new Point(1, 1),
+            new Point(-1, -7)
+        };
+        int NUMPOINTS = POINTS.length;
+
+        LaunchInterceptorConditions LIC = new LaunchInterceptorConditions(NUMPOINTS, POINTS, PARAMETERS);
+
+        assertTrue(LIC.getLaunchInterceptorCondition10());
+    }
 
     /**
      * ========================= [ LIC 11 ] ==========================

--- a/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
+++ b/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
@@ -483,6 +483,34 @@ public class LaunchInterceptorConditionsTest {
         );
     }
 
+    /**
+     * Illegal argument value test case for LIC10, ensures an exception is raised if the
+     * value of E_PTS is negative or null.
+     */
+    @Ignore
+    @Test
+    public void LIC10InvalidArgumentNegativeOrNullEpts() {
+        PARAMETERS.E_PTS = 0;
+        PARAMETERS.AREA1 = 1;
+        Point[] POINTS = new Point[]{
+            new Point(0, 2),
+            new Point(1, 2),
+            new Point(2, 5),
+            new Point(0, 0),
+            new Point(1, 10),
+            new Point(1, 2),
+            new Point(2, 0)
+        };
+        int NUMPOINTS = POINTS.length;
+
+        LaunchInterceptorConditions LIC = new LaunchInterceptorConditions(NUMPOINTS, POINTS, PARAMETERS);
+
+        assertThrows(
+            IllegalArgumentException.class, 
+            () -> { LIC.getLaunchInterceptorCondition10(); }
+        );
+    }
+
 
     
     /**

--- a/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
+++ b/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
@@ -383,6 +383,34 @@ public class LaunchInterceptorConditionsTest {
         assertTrue(LIC.getLaunchInterceptorCondition10());
     }
 
+
+    /**
+     * Negative test case, ensure LIC10 is not satisfied when three points seperated by
+     * exactly E_PTS and F_PTS consecutive pointsrespectively form a triangle of area
+     * inferior  than AREA1 apart.
+     */
+    @Ignore
+    @Test
+    public void LIC10FalseTriangleOfAreaInferiorToArea1() {
+        PARAMETERS.E_PTS = 2;
+        PARAMETERS.E_PTS = 2;
+        PARAMETERS.AREA1 = 3;
+        Point[] POINTS = new Point[]{
+            new Point(0, 1),
+            new Point(1, 2),
+            new Point(2, 5),
+            new Point(0, 0),
+            new Point(1, 10),
+            new Point(1, 2),
+            new Point(1, 0)
+        };
+        int NUMPOINTS = POINTS.length;
+
+        LaunchInterceptorConditions LIC = new LaunchInterceptorConditions(NUMPOINTS, POINTS, PARAMETERS);
+
+        assertFalse(LIC.getLaunchInterceptorCondition10());
+    }
+
     /**
      * ========================= [ LIC 11 ] ==========================
      */

--- a/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
+++ b/decide-app/src/test/java/com/decide/app/LaunchInterceptorConditionsTest.java
@@ -440,6 +440,25 @@ public class LaunchInterceptorConditionsTest {
     }
 
     /**
+     * Unsufficient input test for LIC10, must return false if there are 5 points or less
+     */
+    @Ignore
+    @Test
+    public void LIC10FalseOn5PointsOrLess() {
+        Point[] POINTS = new Point[]{
+            new Point(0, 2),
+            new Point(1, 2)
+        };
+        int NUMPOINTS = POINTS.length;
+
+        LaunchInterceptorConditions LIC = new LaunchInterceptorConditions(NUMPOINTS, POINTS, PARAMETERS);
+
+        assertFalse(LIC.getLaunchInterceptorCondition10());
+    }
+
+
+    
+    /**
      * ========================= [ LIC 11 ] ==========================
      */
 


### PR DESCRIPTION
Implement LIC10 with a positive and a negative test case, an edge-case test, an insufficient input test case (less than  5 points) and the following invalid argument tests:
- strictly negative AREA1
- negative or null E_PTS
- negative or null F_PTS
- E_PTS + F_PTS > NUMPOINTS - 3 

Closes #18.